### PR TITLE
enhancement/5999 ohsomeNow stats

### DIFF
--- a/frontend/src/components/homepage/styles.scss
+++ b/frontend/src/components/homepage/styles.scss
@@ -358,3 +358,9 @@
     padding-bottom: 3.345rem;
   }
 }
+
+.info-ohsome-tooltip {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 0.875rem;
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1210,7 +1210,7 @@
   "home.contact.thanksError": "One moment, there was a problem sending your message.",
   "home.contact.thanksBody": "You'll be hearing from us soon!",
   "home.contact.thanksProceed": "Proceed",
-  "home.statsTooltip": "These statistics come from ohsomeNow Stats and were last updated at {formattedDate} {timeZone}. Missing fields will be made available soon!",
+  "home.statsTooltip": "These statistics come from ohsomeNow Stats and were last updated at {formattedDate} ({timeZone}). Missing fields will be made available soon!",
   "pages.about.description": "The purpose of the Tasking Manager is to divide a large mapping project into smaller tasks that can be completed rapidly and collaboratively, with many people contributing to a collective project goal. The tool shows what needs to be mapped, which areas need to be reviewed and validated for quality assurance and which areas are completed.",
   "pages.about.description2": "This approach allows the distribution of tasks to many individual mappers. It also allows monitoring of project progress and helps to improve the consistency of the mapping (e.g. elements to cover, specific tags to use, etc.)",
   "pages.about.OpenStreetMap.description": "All work is done through {osmLink}. OpenStreetMap is the community-driven free and editable map of the world, supported by the not-for-profit OpenStreetMap Foundation.",

--- a/frontend/src/views/home.js
+++ b/frontend/src/views/home.js
@@ -50,7 +50,7 @@ export function Home() {
         }
       >
         <StatsSection />
-        <div>
+        <div className="info-ohsome-tooltip">
           <InfoIcon
             className="blue-grey h1 w1 v-mid ml2 pointer"
             data-tip={intl.formatMessage(messages['statsTooltip'], {


### PR DESCRIPTION
- Restructured API Endpoints for ohsomeNow stats
- Implementing production API endpoints for ohsomeNow stats retrieval
- Simplify API request URL and update statistics base URL
- Add `StatsTimestamp` component
- Revise generic tooltip (ohsomeNow Stats) message
- Update test cases to reflect API restructuring
- Fix UTC to user location conversion issue in My Contributions
- feat: add tooltip to ohsomeNow stats section in homepage
- style ohsomeNow stat tooltip in home page
