### PR TITLE
enhancement/5999 ohsomeNow stats

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -617,7 +617,7 @@
   "project.stats.changesets": "Changesets",
   "project.stats.edits": "Edits",
   "stats.ohsome.timestamp.generic": "These statistics come from ohsomeNow Stats and were last updated at {formattedDate} ({timeZone}). Missing fields will be made available soon!",
-  "stats.ohsome.timestamp.project": "These stats were retrieved using the default changeset comment of the project and were last updated at {formattedDate}",
+  "stats.ohsome.timestamp.project": "These stats were retrieved using the default changeset comment of the project and were last updated at {formattedDate} ({timeZone})",
   "project.tasks.unsaved_map_changes.title": "You have some unsaved map changes",
   "project.tasks.unsaved_map_changes.split": "Save or undo it to be able to split the task",
   "project.tasks.unsaved_map_changes.unlock": "Save or undo it to be able to select another task",


### PR DESCRIPTION
- Restructured API Endpoints for ohsomeNow stats
- Implementing production API endpoints for ohsomeNow stats retrieval
- Simplify API request URL and update statistics base URL
- Add `StatsTimestamp` component
- Revise generic tooltip (ohsomeNow Stats) message
- Update test cases to reflect API restructuring
- Fix UTC to user location conversion issue in My Contributions
- feat: add tooltip to ohsomeNow stats section in homepage
- style ohsomeNow stat tooltip in home page
- add TimeZone information to project stats Tooltip
