### PR TITLE
fix/6133 markdown editor glitch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,12 @@
-"Component: Frontend":
+"codebase: frontend":
   - frontend/**/*
-"Component: Backend":
+"codebase: backend":
   - backend/**/*
   - tests/**/*
   - migrations/**/*
   - ./manage.py
   - ./pyproject.toml
-"Component: Infrastructure":
+"infrastructure":
   - .circleci/*
   - .github/**/*
   - scripts/aws/**/*
@@ -20,5 +20,5 @@
   - frontend/yarn.lock
 "python":
   - ./pyproject.toml
-"Type: Translations":
+"type: translations":
   - frontend/src/locales/*

--- a/frontend/src/assets/styles/_extra.scss
+++ b/frontend/src/assets/styles/_extra.scss
@@ -616,3 +616,8 @@ a[href="https://www.mapbox.com/map-feedback/"]
 .link:focus {
   outline: revert;
 }
+
+// Override tachyons font-family for code tag
+.code {
+  font-family: inherit;
+}


### PR DESCRIPTION
- Restructured API Endpoints for ohsomeNow stats
- Implementing production API endpoints for ohsomeNow stats retrieval
- Simplify API request URL and update statistics base URL
- Add `StatsTimestamp` component
- Revise generic tooltip (ohsomeNow Stats) message
- Update test cases to reflect API restructuring
- Fix UTC to user location conversion issue in My Contributions
- feat: add tooltip to ohsomeNow stats section in homepage
- style ohsomeNow stat tooltip in home page
- add TimeZone information to project stats Tooltip
- refactor ohsomeNow stat tooltip to use same StatsTimestamp component
- fix stats tooltip typo
- Revert changes to yarn.lock in #6021 (#6076)
- replace zero with - for ohsomeNow stats no value case in My Contributions
- Fix syntax error parsing JSON string
- Update CircleCI AWS CLI Orb syntax
- Remove Postgis extension creation
- fix: unable to access draft and private projects
- Enable IPv6 for Application Load Balancers
- Enable IPv6 for RDS databases
- Make RDS databases publicly inaccessible
- Remove IPv6 for databases
- Roadmap link updated
- Roadmap link update
- Fix crash issue when user logout from settings page
- updating latest label names
