### PR TITLE
fix/6131 stats page crash for archived projects

### DIFF
--- a/frontend/src/components/projectStats/contributorsStats.js
+++ b/frontend/src/components/projectStats/contributorsStats.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Chart as ChartJS, ArcElement, BarElement } from 'chart.js';
+import { Chart as ChartJS, ArcElement, BarElement, CategoryScale, LinearScale } from 'chart.js';
 import { Doughnut, Bar } from 'react-chartjs-2';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -10,7 +10,7 @@ import { formatChartData, formatTooltip } from '../../utils/formatChartJSData';
 import { useContributorStats } from '../../hooks/UseContributorStats';
 import { StatsCardContent } from '../statsCard';
 
-ChartJS.register(ArcElement, BarElement);
+ChartJS.register(ArcElement, BarElement, CategoryScale, LinearScale);
 
 export default function ContributorsStats({ contributors }) {
   const intl = useIntl();


### PR DESCRIPTION
- Update working-groups.md
- fix: Move working-groups to docs after it got updated
- fix: Add updated docs from docs-old
- fix: Fix link to images
- fix: Move error_code.md to developers, migration.md to sysadmin
- fix: Remove erd.md
- fix: Delete old images that have been replace by the new diagrams
- fix: Remove doc that was already migrated and updated in docs
- fix: Fix relative links, add new docs to the menu
- fix: Add dataflow page for diagrams
- fix: Fix links to docs
- fix: For now make the index the about page
- fix: Adjust links for docs that got moved to developers directory
- fix: Fix links to images
- fix: Adjust links for docs that got moved to developers directory
- fix: Use hard word wrap for test editors
- fix: Move some docs to developers, add deep tech dive section
- Fix `Project Stats` page crash issue for archived projects
