### PR TITLE
fix/6339 use default changeset comment in ohsome api

### DIFF
--- a/frontend/src/api/stats.js
+++ b/frontend/src/api/stats.js
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchExternalJSONAPI } from '../network/genericJSONRequest';
 import api from './apiClient';
-import { OHSOME_STATS_BASE_URL } from '../config';
+import { OHSOME_STATS_BASE_URL, defaultChangesetComment } from '../config';
 
 const ohsomeProxyAPI = (url) => {
   const token = localStorage.getItem('token');
@@ -39,7 +39,7 @@ export const useProjectStatisticsQuery = (projectId) => {
 
 export const useOsmStatsQuery = () => {
   const fetchOsmStats = ({ signal }) => {
-    return api().get(`${OHSOME_STATS_BASE_URL}/stats/hotosm-project-%2A`, {
+    return api().get(`${OHSOME_STATS_BASE_URL}/stats/${defaultChangesetComment}`, {
       signal,
     });
   };

--- a/frontend/src/components/teamsAndOrgs/featureStats.js
+++ b/frontend/src/components/teamsAndOrgs/featureStats.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 import userDetailMessages from '../userDetail/messages';
-import { OHSOME_STATS_BASE_URL } from '../../config';
+import { OHSOME_STATS_BASE_URL, defaultChangesetComment } from '../../config';
 import { RoadIcon, HomeIcon, WavesIcon, MarkerIcon } from '../svgIcons';
 import { StatsCard } from '../statsCard';
 import StatsTimestamp from '../statsTimestamp';
@@ -13,7 +13,7 @@ export const FeatureStats = () => {
   const [stats, setStats] = useState({ edits: 0, buildings: 0, roads: 0, pois: 0, waterways: 0 });
   const getStats = async () => {
     try {
-      const response = await axios.get(`${OHSOME_STATS_BASE_URL}/stats/hotosm-project-%2A`);
+      const response = await axios.get(`${OHSOME_STATS_BASE_URL}/stats/${defaultChangesetComment}`);
       const { edits, buildings, roads } = response.data.result;
       setStats({
         edits,

--- a/frontend/src/config/index.js
+++ b/frontend/src/config/index.js
@@ -184,3 +184,5 @@ export const DROPZONE_SETTINGS = {
   // At time of writing, this workaround is only needed on Chromium based browsers.
   noClick: true,
 };
+
+export const defaultChangesetComment = TM_DEFAULT_CHANGESET_COMMENT.replace('#', '');

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -69,7 +69,7 @@ import {
   ohsomeNowMetadata,
 } from './mockData/miscellaneous';
 import tasksGeojson from '../../utils/tests/snippets/tasksGeometry';
-import { API_URL, OHSOME_STATS_BASE_URL } from '../../config';
+import { API_URL, OHSOME_STATS_BASE_URL, defaultChangesetComment } from '../../config';
 import { notifications, ownCountUnread } from './mockData/notifications';
 import { authLogin, setUser, userRegister } from './mockData/auth';
 import {
@@ -349,7 +349,7 @@ const handlers = [
     return res(ctx.json(systemStats));
   }),
   // EXTERNAL API
-  rest.get(`${OHSOME_STATS_BASE_URL}/stats/hotosm-project-%2A`, (req, res, ctx) => {
+  rest.get(`${OHSOME_STATS_BASE_URL}/stats/${defaultChangesetComment}`, (req, res, ctx) => {
     return res(ctx.json(homepageStats));
   }),
   rest.get(`${OHSOME_STATS_BASE_URL}/hot-tm-user`, (req, res, ctx) => {


### PR DESCRIPTION
- **+ Live monitoring with Underpass**
- **Add underpass-ui package**
- **+ Live Monitoring view**
- **Change Underpass UI package URL**
- **Update underpass-ui package**
- **Update Underpass UI package, now published to the NPM registry**
- **feat: ohsome proxy api for user stats**
- **Integrate proxy api for ohsomeNow stats**
- **Fix Frontend Test Case failure on CI**
- **fix: image displaying in email content for comments**
- **Enable `Live Monitoring` feature only when `Expert Mode` is turned on**
- **Move underpass configs to config/underpass file**
- **Remove `Footer` in `Live Monitoring View`**
- **Add `Edit Project` button on `Task Selection` page**
- **Change `Twitter Icon` to `X`**
- **Add default changeset comment from env in ohsome API**
