### PR TITLE
fix/6425 crash when language switched to nederlands

### DIFF
--- a/frontend/src/utils/countries.js
+++ b/frontend/src/utils/countries.js
@@ -20,7 +20,8 @@ export function getCountryCode(name) {
 }
 
 export function isLangSupported(code) {
-  if (getSupportedLangs().includes(code.split('-')[0])) return true;
+  // split with `-` or `_` to get the language initials
+  if (getSupportedLangs().includes(code.split(/[-_]/)[0])) return true;
   return false;
 }
 

--- a/frontend/src/utils/internationalization.js
+++ b/frontend/src/utils/internationalization.js
@@ -24,7 +24,7 @@ const supportedLocales = [
   { value: 'ko', label: '한국어' },
   // { value: 'mg', label: 'Malagasy' },
   // { value: 'ml', label: 'Malayalam' },
-  { value: 'nl', label: 'Nederlands' },
+  { value: 'nl_NL', label: 'Nederlands' },
   { value: 'pt', label: 'Português' },
   { value: 'pt-BR', label: 'Português (Brasil)' },
   // { value: 'ru', label: 'Русский язык' },

--- a/frontend/src/utils/tests/internationalization.test.js
+++ b/frontend/src/utils/tests/internationalization.test.js
@@ -31,7 +31,7 @@ describe('getSupportedLocale', () => {
   it('returns a generic supported locale if the variation is not supported', () => {
     expect(getSupportedLocale('en-gb')).toEqual({ label: 'English', value: 'en' });
     expect(getSupportedLocale('es-AR')).toEqual({ label: 'Español', value: 'es' });
-    expect(getSupportedLocale('nl-NL')).toEqual({ label: 'Nederlands', value: 'nl' });
+    expect(getSupportedLocale('nl_NL')).toEqual({ label: 'Nederlands', value: 'nl_NL' });
   });
   it('returns the default locale if the code is not supported and does not have a variation', () => {
     expect(getSupportedLocale('xt')).toEqual({ label: 'English', value: 'en' });


### PR DESCRIPTION
- **made the main page static and enabled scrolling in the filters component**
- **Solved the height issue of filters menu**
- **minor changes**
- **added dependency array**
- **remove the css for hiding scroll bar**
- **Made dropdowns fixed and hide scroll bar**
- **removed comments**
- **solved the front end test error**
- **removed comments**
- **Prevent api call before filter apply in `Explore Projects` page**
- **Fix z-index issue between select dropdown and toggle button in more filter popover**
- **Increase padding in more filters footer button in more filter**
- **Change More Filter to popover layout in laptop screen**
- **Add overlay on More Filter popover**
- **Close More Filter popover on outside click**
- **Fix test case for More Filters**
- **Prevent More Filter popover close on clearing selected filter**
- **Fix project page not scrolling on More Filter popover**
- **Fix More Filter popover position on page scroll**
- **Fix More Filter popover overlay height**
- **Validate empty project name while creating project**
- **Validate symbols and number in first charater of project name**
- **Validate empty project name while editing project**
- **Validate symbols and number in first charater of project name during edit**
- **Fix mismatch value for language json file for Nederlands**
- **Fix test case failure for `nl_NL` language**
