### PR TITLE
fix/6425 crash when language switched to nederlands

### DIFF
--- a/frontend/src/utils/countries.js
+++ b/frontend/src/utils/countries.js
@@ -2,7 +2,7 @@ import { getCountries, getCountry, getSupportedLangs } from '@hotosm/iso-countri
 
 export function translateCountry(name, locale) {
   const code = getCountryCode(name);
-  if (code && isLangSupported(locale)) return getCountry(locale.split('-')[0], code);
+  if (code && isLangSupported(locale)) return getCountry(locale.split(/[-_]/)[0], code);
   return name;
 }
 
@@ -27,7 +27,7 @@ export function isLangSupported(code) {
 
 export function formatCountryList(locale) {
   if (locale && isLangSupported(locale)) {
-    const countries = getCountries(locale.split('-')[0]);
+    const countries = getCountries(locale.split(/[-_]/)[0]);
     return Object.keys(countries).map((key) => ({ label: countries[key], value: key }));
   }
 }


### PR DESCRIPTION
- **made the main page static and enabled scrolling in the filters component**
- **Solved the height issue of filters menu**
- **minor changes**
- **added dependency array**
- **remove the css for hiding scroll bar**
- **Made dropdowns fixed and hide scroll bar**
- **removed comments**
- **solved the front end test error**
- **removed comments**
- **Prevent api call before filter apply in `Explore Projects` page**
- **Fix z-index issue between select dropdown and toggle button in more filter popover**
- **Increase padding in more filters footer button in more filter**
- **Change More Filter to popover layout in laptop screen**
- **Add overlay on More Filter popover**
- **Close More Filter popover on outside click**
- **Fix test case for More Filters**
- **Prevent More Filter popover close on clearing selected filter**
- **Fix project page not scrolling on More Filter popover**
- **Fix More Filter popover position on page scroll**
- **Fix More Filter popover overlay height**
- **Validate empty project name while creating project**
- **Validate symbols and number in first charater of project name**
- **Validate empty project name while editing project**
- **Validate symbols and number in first charater of project name during edit**
- **Fix mismatch value for language json file for Nederlands**
- **Fix test case failure for `nl_NL` language**
- **Fix undefined issue when language toggle to Nederlands**
