### PR TITLE
refactor/partners page code

### DIFF
--- a/frontend/src/components/partners/partners.js
+++ b/frontend/src/components/partners/partners.js
@@ -140,13 +140,17 @@ export function PartnersForm(props) {
               </form>
               {props.errorMessage && (
                 <div className="mt2">
-                  <Alert type="error" compact>
-                    {props.errorMessage ? (
-                      <span>{props.errorMessage}</span>
-                    ) : (
-                      <FormattedMessage {...viewsMessages[`errorFallback`]} />
-                    )}
-                  </Alert>
+                  {props.errorMessage && (
+                    <Alert type="error" compact>
+                      {viewsMessages[`partnerEdit${props.errorMessage}Error`] ? (
+                        <FormattedMessage
+                          {...viewsMessages[`partnerEdit${props.errorMessage}Error`]}
+                        />
+                      ) : (
+                        <FormattedMessage {...viewsMessages[`errorFallback`]} />
+                      )}
+                    </Alert>
+                  )}
                 </div>
               )}
             </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1170,6 +1170,7 @@
   "teamsAndOrgs.management.organisation.button.create": "Create organization",
   "management.partner.button.create": "Create Partner",
   "management.partner.creation.error": "Partner name already exists",
+  "management.partner.edit.error": "Partner name already exists",
   "management.partner.learnToMap": "Learn to Map",
   "management.partner.currentProjects": "Current Projects",
   "management.partner.newToMapping": "¿New to Mapping?",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1169,6 +1169,7 @@
   "teamsAndOrgs.management.campaign.creation": "Create new campaign",
   "teamsAndOrgs.management.organisation.button.create": "Create organization",
   "management.partner.button.create": "Create Partner",
+  "management.partner.creation.error": "Partner name already exists",
   "management.partner.learnToMap": "Learn to Map",
   "management.partner.currentProjects": "Current Projects",
   "management.partner.newToMapping": "¿New to Mapping?",

--- a/frontend/src/views/messages.js
+++ b/frontend/src/views/messages.js
@@ -120,6 +120,10 @@ export default defineMessages({
     id: 'management.partner.creation.error',
     defaultMessage: 'Partner name already exists',
   },
+  partnerEditNameExistsError: {
+    id: 'management.partner.edit.error',
+    defaultMessage: 'Partner name already exists',
+  },
   learnToMap: {
     id: 'management.partner.learnToMap',
     defaultMessage: 'Learn to Map',

--- a/frontend/src/views/messages.js
+++ b/frontend/src/views/messages.js
@@ -116,15 +116,19 @@ export default defineMessages({
     id: 'management.partner.button.create',
     defaultMessage: 'Create Partner',
   },
-  learnToMap:{
+  partnerCreationNameExistsError: {
+    id: 'management.partner.creation.error',
+    defaultMessage: 'Partner name already exists',
+  },
+  learnToMap: {
     id: 'management.partner.learnToMap',
     defaultMessage: 'Learn to Map',
   },
-  currentProjects:{
+  currentProjects: {
     id: 'management.partner.currentProjects',
     defaultMessage: 'Current Projects',
   },
-  newToMapping:{
+  newToMapping: {
     id: 'management.partner.newToMapping',
     defaultMessage: '¿New to Mapping?',
   },
@@ -200,13 +204,11 @@ export default defineMessages({
   },
   editPartnerNotAllowed: {
     id: 'teamsAndOrgs.management.partner.manage.error',
-    defaultMessage:
-      'You are not a manager of this partner, so you are not allowed to edit it.',
+    defaultMessage: 'You are not a manager of this partner, so you are not allowed to edit it.',
   },
-  notAllowedCreatePartners:{
+  notAllowedCreatePartners: {
     id: 'teamsAndOrgs.management.partner.create.error',
-    defaultMessage:
-      'You are not allowed to access the management area.',
+    defaultMessage: 'You are not allowed to access the management area.',
   },
   tasksStatistics: {
     id: 'teamsAndOrgs.management.organisation.stats',

--- a/frontend/src/views/partnersManagement.js
+++ b/frontend/src/views/partnersManagement.js
@@ -74,15 +74,17 @@ export function CreatePartner() {
         navigate('/manage/partners');
       })
       .catch((err) => {
-        setError(err.message);
+        setError(err);
       });
   };
+
   useEffect(() => {
     if (!token && !userDetails?.id) {
       navigate('/login');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userDetails, token]);
+
   return (
     <div>
       {userDetails.role === 'ADMIN' ? (
@@ -100,8 +102,10 @@ export function CreatePartner() {
                     <div className="cf pv2 ml2">
                       {error && (
                         <Alert type="error" compact>
-                          {messages[`partnerCreation${error}Error`] ? (
-                            <FormattedMessage {...messages[`partnerCreation${error}Error`]} />
+                          {messages[`partnerCreation${error.message}Error`] ? (
+                            <FormattedMessage
+                              {...messages[`partnerCreation${error.message}Error`]}
+                            />
                           ) : (
                             <FormattedMessage
                               {...messages.entityCreationFailure}


### PR DESCRIPTION
- **ref: frontend tests now has parallel workers & removed warnings**
- **add: general pre-commit hooks for static code checks**
- **pre-commit: run --all-files applied**
- **applied pre-commit run-all files for end-of-file-fixer & trailing-whitespace**
- **Remove `Footer` in `Create New Partner` page**
- **Remove grain background in `Manage Partners` section**
- **Do not fetch data if current projects is null in `Partners Page`**
- **Add `no current projects` placeholder text for no projects in `Partners Page`**
- **Left align Add/Edit Partners content**
- **Adjust content spacing in `Partners Page`**
- **Changes in `Partners Page` Design**
- **Add `Resources` tab for other links in `Partners Page`**
- **Show `Resources` tab only when links are available**
- **Fix grey background color in switch component**
- **Show only 2 primary hashtags in `Partners` card view**
- **[pre-commit.ci] auto fixes from pre-commit.com hooks**
- **Add base url referrer to Nominatum api**
- **build: update cloudformation config to use pdm export instead of venv**
- **build: add --user flag to cloudformation pip install (avoid sys conflicts)**
- **Set path to use root user local dir for python packages installed locally**
- **Partners table atrributes lengths adjusted**
- **Fix activity section loading forever on secondary hashtag empty issue**
- **Display partner name in the banner when logo not present**
- **Refactor Partners card component**
- **Change inline styles to tachyons classes in Partners page**
- **Reorder Activity section of Partners page**
- **Change translation texts for Partners Stats page**
- **Use short description in Partners Stats Current Project section**
- **Fix console error for `class instead of className` in Partners Stats page**
- **Add stats info footer in Partners Stats page**
- **Add contribution number to Current Projects in Partners Stats**
- **Adjust styling in Current Projects section Partners page**
- **Show partner creation error message from backend**
