### PR TITLE
Feat/7216 campaign message contributors

### DIFF
--- a/frontend/src/components/teamsAndOrgs/campaigns.js
+++ b/frontend/src/components/teamsAndOrgs/campaigns.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { Form, Field } from 'react-final-form';
@@ -11,7 +12,7 @@ import { Button } from '../button';
 import { HashtagIcon } from '../svgIcons';
 import { TextField } from '../formInputs';
 
-export function CampaignsManagement({ campaigns, userDetails, isCampaignsFetched }: Object) {
+export function CampaignsManagement({ campaigns, userDetails, isCampaignsFetched }) {
   const [query, setQuery] = useState('');
 
   const onSearchInputChange = (e) => setQuery(e.target.value);
@@ -57,7 +58,7 @@ export function CampaignsManagement({ campaigns, userDetails, isCampaignsFetched
   );
 }
 
-export function CampaignCard({ campaign }: Object) {
+export function CampaignCard({ campaign }) {
   return (
     <Link to={`${campaign.id}/`} className="w-50-ns w-100 fl pr3">
       <div className="cf bg-white blue-dark br1 mv2 pv4 ph3 ba br1 b--grey-light shadow-hover">
@@ -84,7 +85,14 @@ export function CampaignInformation(props) {
         <label className={labelClasses} htmlFor="name">
           <FormattedMessage {...messages.name} />
         </label>
-        <Field id="name" name="name" component="input" type="text" className={fieldClasses} required />
+        <Field
+          id="name"
+          name="name"
+          component="input"
+          type="text"
+          className={fieldClasses}
+          required
+        />
       </div>
     </>
   );
@@ -153,3 +161,14 @@ export function CampaignForm({
     ></Form>
   );
 }
+
+CampaignForm.propTypes = {
+  userDetails: PropTypes.object,
+  campaign: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+  }),
+  updateCampaignAsync: PropTypes.object,
+  disabled: PropTypes.bool,
+  disableErrorAlert: PropTypes.func,
+};

--- a/frontend/src/components/teamsAndOrgs/campaigns.js
+++ b/frontend/src/components/teamsAndOrgs/campaigns.js
@@ -58,6 +58,19 @@ export function CampaignsManagement({ campaigns, userDetails, isCampaignsFetched
   );
 }
 
+CampaignsManagement.propTypes = {
+  campaigns: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    }),
+  ),
+  userDetails: PropTypes.shape({
+    role: PropTypes.string,
+  }),
+  isCampaignsFetched: PropTypes.bool,
+};
+
 export function CampaignCard({ campaign }) {
   return (
     <Link to={`${campaign.id}/`} className="w-50-ns w-100 fl pr3">
@@ -74,6 +87,13 @@ export function CampaignCard({ campaign }) {
     </Link>
   );
 }
+
+CampaignCard.propTypes = {
+  campaign: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+  }),
+};
 
 export function CampaignInformation(props) {
   const labelClasses = 'db pt3 pb2';
@@ -98,13 +118,9 @@ export function CampaignInformation(props) {
   );
 }
 
-export function CampaignForm({
-  userDetails,
-  campaign,
-  updateCampaignAsync,
-  disabled,
-  disableErrorAlert,
-}) {
+CampaignInformation.propTypes = {};
+
+export function CampaignForm({ campaign, updateCampaignAsync, disabled, disableErrorAlert }) {
   return (
     <Form
       key={campaign.id || 'new'}
@@ -117,7 +133,6 @@ export function CampaignForm({
         dirtySinceLastSubmit,
         form,
         submitting,
-        values,
       }) => {
         const dirtyForm = submitSucceeded ? dirtySinceLastSubmit && dirty : dirty;
         if (dirtySinceLastSubmit) {
@@ -163,7 +178,6 @@ export function CampaignForm({
 }
 
 CampaignForm.propTypes = {
-  userDetails: PropTypes.object,
   campaign: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,

--- a/frontend/src/components/teamsAndOrgs/campaigns.js
+++ b/frontend/src/components/teamsAndOrgs/campaigns.js
@@ -81,10 +81,10 @@ export function CampaignInformation(props) {
   return (
     <>
       <div className="cf">
-        <label className={labelClasses}>
+        <label className={labelClasses} htmlFor="name">
           <FormattedMessage {...messages.name} />
         </label>
-        <Field name="name" component="input" type="text" className={fieldClasses} required />
+        <Field id="name" name="name" component="input" type="text" className={fieldClasses} required />
       </div>
     </>
   );
@@ -99,6 +99,7 @@ export function CampaignForm({
 }) {
   return (
     <Form
+      key={campaign.id || 'new'}
       onSubmit={(values) => updateCampaignAsync.execute(values)}
       initialValues={campaign}
       render={({

--- a/frontend/src/components/teamsAndOrgs/messageContributors.js
+++ b/frontend/src/components/teamsAndOrgs/messageContributors.js
@@ -2,6 +2,7 @@ import { lazy, Suspense, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 import toast from 'react-hot-toast';
+import PropTypes from 'prop-types';
 
 import messages from './messages';
 import { Button } from '../button';
@@ -104,3 +105,6 @@ export function MessageContributors({ campaignId }) {
     </>
   );
 }
+MessageContributors.propTypes = {
+  campaignId: PropTypes.number,
+};

--- a/frontend/src/components/teamsAndOrgs/messageContributors.js
+++ b/frontend/src/components/teamsAndOrgs/messageContributors.js
@@ -1,0 +1,106 @@
+import { lazy, Suspense, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { FormattedMessage } from 'react-intl';
+import toast from 'react-hot-toast';
+
+import messages from './messages';
+import { Button } from '../button';
+import { MessageStatus } from '../comments/status';
+import { pushToLocalJSONAPI } from '../../network/genericJSONRequest';
+import ReactPlaceholder from 'react-placeholder';
+
+const CommentInputField = lazy(() =>
+  import('../comments/commentInput' /* webpackChunkName: "commentInput" */),
+);
+
+export function MessageContributors({ campaignId }) {
+  const token = useSelector((state) => state.auth.token);
+  const [message, setMessage] = useState('');
+  const [subject, setSubject] = useState('');
+  const [status, setStatus] = useState(null);
+
+  const sendMessage = () => {
+    if (message && subject && token) {
+      setStatus('sending');
+      pushToLocalJSONAPI(
+        `campaigns/${campaignId}/actions/message-contributors/`,
+        JSON.stringify({ message: message, subject: subject }),
+        token,
+        'POST',
+      )
+        .then(() => {
+          toast.success(<FormattedMessage {...messages.sendMessageSuccess} />);
+          setStatus('messageSent');
+          setMessage('');
+          setSubject('');
+        })
+        .catch(() => {
+          toast.error(<FormattedMessage {...messages.sendMessageFailure} />);
+          setStatus('error');
+        });
+    }
+  };
+
+  return (
+    <>
+      <div className={`bg-white b--grey-light pa4 ${message ? 'bt bl br' : 'ba'}`}>
+        <div className="cf db">
+          <h3 className="f3 blue-dark mt0 fw6 fl">
+            <FormattedMessage {...messages.messageContributors} />
+          </h3>
+        </div>
+        {(message || subject) && (
+          <div className="cf mb1">
+            <FormattedMessage {...messages.subjectPlaceholder}>
+              {(msg) => {
+                return (
+                  <input
+                    value={subject}
+                    onChange={(e) => setSubject(e.target.value)}
+                    name="subject"
+                    className="db center pa2 w-100 fl mb3"
+                    type="text"
+                    placeholder={msg}
+                  />
+                );
+              }}
+            </FormattedMessage>
+          </div>
+        )}
+        <div className="cf mb1">
+          <Suspense
+            fallback={<ReactPlaceholder showLoadingAnimation={true} rows={10} delay={300} />}
+          >
+            <CommentInputField comment={message} setComment={setMessage} isShowTabNavs />
+          </Suspense>
+        </div>
+        {!message && <MessageStatus status={status} />}
+      </div>
+      {(message || subject) && (
+        <div className="cf pt0">
+          <div className="w-70-l w-50 fl tr dib bg-grey-light">
+            <Button
+              className="blue-dark bg-grey-light h3"
+              onClick={() => {
+                setMessage('');
+                setSubject('');
+                setStatus(null);
+              }}
+            >
+              <FormattedMessage {...messages.cancel} />
+            </Button>
+          </div>
+          <div className="w-30-l w-50 fr dib">
+            <Button
+              className="white bg-red h3 w-100"
+              onClick={() => sendMessage()}
+              disabled={!message || !subject}
+            >
+              <FormattedMessage {...messages.send} />
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/teamsAndOrgs/messageContributors.js
+++ b/frontend/src/components/teamsAndOrgs/messageContributors.js
@@ -75,7 +75,7 @@ export function MessageContributors({ campaignId }) {
             <CommentInputField comment={message} setComment={setMessage} isShowTabNavs />
           </Suspense>
         </div>
-        {!message && <MessageStatus status={status} />}
+        {!message && status && <MessageStatus status={status} />}
       </div>
       {(message || subject) && (
         <div className="cf pt0">
@@ -94,7 +94,7 @@ export function MessageContributors({ campaignId }) {
           <div className="w-30-l w-50 fr dib">
             <Button
               className="white bg-red h3 w-100"
-              onClick={() => sendMessage()}
+              onClick={sendMessage}
               disabled={!message || !subject}
             >
               <FormattedMessage {...messages.send} />

--- a/frontend/src/components/teamsAndOrgs/messages.js
+++ b/frontend/src/components/teamsAndOrgs/messages.js
@@ -81,6 +81,10 @@ export default defineMessages({
     id: 'management.teams.members.send_message',
     defaultMessage: 'Team messaging',
   },
+  messageContributors: {
+    id: 'management.campaigns.contributors.send_message',
+    defaultMessage: 'Message contributors',
+  },
   sendMessageSuccess: {
     id: 'management.teams.members.send_message.success',
     defaultMessage: 'Message sent',

--- a/frontend/src/views/campaigns.js
+++ b/frontend/src/views/campaigns.js
@@ -20,6 +20,7 @@ import { useSetTitleTag } from '../hooks/UseMetaTags';
 import { Alert, EntityError } from '../components/alert';
 import { useAsync } from '../hooks/UseAsync';
 import { updateEntity } from '../utils/management';
+import { MessageContributors } from '../components/teamsAndOrgs/messageContributors';
 
 export const CampaignError = ({ error }) => {
   return (
@@ -159,6 +160,8 @@ export function EditCampaign() {
           disableErrorAlert={() => nameError && setNameError(false)}
         />
         <CampaignError error={nameError} />
+        <div className="h1"></div>
+        <MessageContributors campaignId={campaign.id} />
       </div>
       <div className="w-60-l w-100 mt4 pl5-l pl0 fl">
         <Projects

--- a/frontend/src/views/tests/campaigns.test.js
+++ b/frontend/src/views/tests/campaigns.test.js
@@ -80,7 +80,7 @@ describe('CreateCampaign', () => {
 
   it('should enable create campaign button when the value is changed', async () => {
     const { user, createButton } = setup();
-    const inputText = screen.getByRole('textbox');
+    const inputText = screen.getByRole('textbox', { name: /name/i });
     await user.clear(inputText);
     await user.type(inputText, 'New Campaign Name');
     expect(createButton).toBeEnabled();
@@ -95,7 +95,7 @@ describe('CreateCampaign', () => {
     const createButton = screen.getByRole('button', {
       name: /create campaign/i,
     });
-    const inputText = screen.getByRole('textbox');
+    const inputText = screen.getByRole('textbox', { name: /name/i });
     await user.clear(inputText);
     await user.type(inputText, 'New Campaign Name');
     expect(inputText.value).toBe('New Campaign Name');
@@ -117,7 +117,7 @@ describe('CreateCampaign', () => {
     const createButton = screen.getByRole('button', {
       name: /create campaign/i,
     });
-    const inputText = screen.getByRole('textbox');
+    const inputText = screen.getByRole('textbox', { name: /name/i });
     await user.clear(inputText);
     await user.type(inputText, 'New Campaign Name');
     expect(inputText.value).toBe('New Campaign Name');
@@ -138,25 +138,28 @@ describe('EditCampaign', () => {
         <EditCampaign id={123} />
       </ReduxIntlProviders>,
     );
-    const inputText = screen.getByRole('textbox');
+
 
     return {
       user,
       container,
-      inputText,
       history,
     };
   };
 
   it('should display the campaign name by default', async () => {
-    const { inputText } = setup();
-    await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
-    expect(inputText.value).toBe('Campaign Name 123');
+    setup();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /name/i }).value).toBe('Campaign Name 123');
+    });
   });
 
   it('should display save button when project name is changed', async () => {
-    const { user, inputText } = setup();
-    await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
+    const { user } = setup();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /name/i }).value).toBe('Campaign Name 123');
+    });
+    const inputText = screen.getByRole('textbox', { name: /name/i });
     await user.clear(inputText);
     await user.type(inputText, 'Changed Campaign Name');
     const saveButton = screen.getByRole('button', {
@@ -166,8 +169,11 @@ describe('EditCampaign', () => {
   });
 
   it('should also display cancel button when project name is changed', async () => {
-    const { user, inputText } = setup();
-    await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
+    const { user } = setup();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /name/i }).value).toBe('Campaign Name 123');
+    });
+    const inputText = screen.getByRole('textbox', { name: /name/i });
     await user.clear(inputText);
     await user.type(inputText, 'Changed Campaign Name');
     const cancelButton = screen.getByRole('button', {
@@ -177,8 +183,11 @@ describe('EditCampaign', () => {
   });
 
   it('should return input text value to default when cancel button is clicked', async () => {
-    const { user, inputText } = setup();
-    await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
+    const { user } = setup();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /name/i }).value).toBe('Campaign Name 123');
+    });
+    const inputText = screen.getByRole('textbox', { name: /name/i });
     await user.clear(inputText);
     await user.type(inputText, 'Changed Campaign Name');
     const cancelButton = screen.getByRole('button', {
@@ -204,8 +213,11 @@ describe('EditCampaign', () => {
   });
 
   it('should hide the save button after campaign edit is successful', async () => {
-    const { user, inputText } = setup();
-    await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
+    const { user } = setup();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /name/i }).value).toBe('Campaign Name 123');
+    });
+    const inputText = screen.getByRole('textbox', { name: /name/i });
     await user.clear(inputText);
     await user.type(inputText, 'Changed Campaign Name');
     const saveButton = screen.getByRole('button', { name: /save/i });
@@ -226,8 +238,11 @@ describe('EditCampaign', () => {
 
   it('should display toast with error has occured message', async () => {
     setupFaultyHandlers();
-    const { user, inputText } = setup();
-    await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
+    const { user } = setup();
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /name/i }).value).toBe('Campaign Name 123');
+    });
+    const inputText = screen.getByRole('textbox', { name: /name/i });
     await user.clear(inputText);
     await user.type(inputText, 'Changed Campaign Name');
     const saveButton = screen.getByRole('button', { name: /save/i });
@@ -245,11 +260,10 @@ describe('Delete Campaign', () => {
         <EditCampaign id={123} />
       </ReduxIntlProviders>,
     );
-    const inputText = screen.getByRole('textbox');
+
 
     return {
       user,
-      inputText,
     };
   };
 


### PR DESCRIPTION
This PR introduces the ability for campaign managers to send messages to all contributors of a specific campaign.

Key Changes:
- New Feature: Added MessageContributors component in frontend/src/components/teamsAndOrgs/messageContributors.js to handle subject and message input for emailing campaign contributors.
- Integration: Integrated the MessageContributors component into the EditCampaign view.
- Accessibility: Updated CampaignInformation to include proper htmlFor and id attributes for the campaign name input field.
- Bug Fix: Added a unique key to the CampaignForm in frontend/src/components/teamsAndOrgs/campaigns.js to ensure the form correctly re-initializes when switching between campaigns.
- i18n: Added new translation strings for the "Message contributors" functionality.