### PR TITLE
Fix Jinja2 autoescape disabled XSS vulnerability

### DIFF
--- a/backend/services/messaging/template_service.py
+++ b/backend/services/messaging/template_service.py
@@ -9,6 +9,7 @@ from backend.config import settings
 # Set up Jinja2 environment
 env = Environment(
     loader=FileSystemLoader(os.path.join(os.path.dirname(__file__), "templates")),
+    autoescape=True,
 )
 
 


### PR DESCRIPTION
Enable autoescape=True in the Jinja2 Environment to prevent cross-site scripting via user-controlled template variables. Flagged by Bandit (B701) and Semgrep.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #123

## Describe this PR

A brief description of how this solves the issue.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?
