### PR TITLE
fix: convert HTML to Markdown in CommentInputField using turndown

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,20 +1,34 @@
 "scope: frontend":
-  - frontend/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - frontend/**/*
+
 "scope: backend":
-  - backend/**/*
-  - tests/**/*
-  - migrations/**/*
-  - ./manage.py
-  - ./pyproject.toml
+- changed-files:
+  - any-glob-to-any-file:
+    - backend/**/*
+    - tests/**/*
+    - migrations/**/*
+    - manage.py
+    - pyproject.toml
+
 "scope: infrastructure":
-  - .circleci/*
-  - .github/**/*
-  - scripts/aws/**/*
-  - scripts/docker/**/*
-  - scripts/install/**/*
-  - docker-*.yml
+- changed-files:
+  - any-glob-to-any-file:
+    - .circleci/*
+    - .github/**/*
+    - scripts/aws/**/*
+    - scripts/docker/**/*
+    - scripts/install/**/*
+    - docker-*.yml
+
 "dependencies":
-  - frontend/yarn.lock
-  - ./pyproject.toml
+- changed-files:
+  - any-glob-to-any-file:
+    - frontend/yarn.lock
+    - pyproject.toml
+
 "scope: translations":
-  - frontend/src/locales/*
+- changed-files:
+  - any-glob-to-any-file:
+    - frontend/src/locales/*

--- a/backend/api/users/statistics.py
+++ b/backend/api/users/statistics.py
@@ -176,7 +176,7 @@ async def get_ohsome_stats(
     db: Database = Depends(get_db),
     userId: int = Query(..., description="OSM user ID"),
     topics: str = Query(
-        ..., description="Comma-separated list of OSM topics, e.g. building,highway"
+        ..., description="Comma-separated list of OSM topics, e.g. building,road"
     ),
     startdate: Optional[str] = Query(
         None, description="YYYY-MM-DD, start of time range"

--- a/example.env
+++ b/example.env
@@ -90,7 +90,7 @@ OSM_USER_AGENT=${OSM_USER_AGENT:-HOT-TaskingManager}
 #
 OHSOME_STATS_BASE_URL=${OHSOME_STATS_BASE_URL:-https://stats.now.ohsome.org}
 OHSOME_STATS_API_URL=${OHSOME_STATS_API_URL:-https://stats.now.ohsome.org/api}
-OHSOME_STATS_TOPICS=${OHSOME_STATS_TOPICS:-highway,waterway,building,poi}
+OHSOME_STATS_TOPICS=${OHSOME_STATS_TOPICS:-road,waterway,building,poi}
 OHSOME_STATS_TOKEN=${OHSOME_STATS_TOKEN:-testSuperSecretTestToken}
 
 # Secret (required)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,6 +71,7 @@
     "terra-draw": "^1.18.1",
     "tributejs": "^5.1.3",
     "turndown": "^7.2.4",
+    "turndown-plugin-gfm": "^1.0.2",
     "use-query-params": "^2.2.1",
     "webfontloader": "^1.6.28",
     "workbox-core": "^7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,6 +70,7 @@
     "tachyons": "^4.12.0",
     "terra-draw": "^1.18.1",
     "tributejs": "^5.1.3",
+    "turndown": "^7.2.4",
     "use-query-params": "^2.2.1",
     "webfontloader": "^1.6.28",
     "workbox-core": "^7.0.0",

--- a/frontend/src/components/badges/messages.js
+++ b/frontend/src/components/badges/messages.js
@@ -11,6 +11,7 @@ export default defineMessages({
   description: { id: 'management.fields.description', defaultMessage: 'Description' },
   hidden: { id: 'management.badges.hidden', defaultMessage: 'Hide this badge from users' },
   highway: { id: 'management.badges.highway', defaultMessage: 'km of highways added' },
+  road: { id: 'management.badges.road', defaultMessage: 'km of roads added' },
   image: { id: 'management.fields.organisation.image', defaultMessage: 'Image' },
   imageError: { id: 'management.badges.imageError', defaultMessage: 'Error uploading image' },
   manage: { id: 'management.link.manage', defaultMessage: 'Manage {entity}' },

--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -13,7 +13,7 @@ import HashtagPaste from './hashtagPaste';
 import FileRejections from './fileRejections';
 import DropzoneUploadStatus from './uploadStatus';
 import { DROPZONE_SETTINGS } from '../../config';
-import { formatUserNamesToLink } from '../../utils/htmlFromMarkdown';
+import { formatUserNamesToLink, markdownFromHtml } from '../../utils/htmlFromMarkdown';
 import { iconConfig } from './editorIconConfig';
 import messages from './messages';
 import { CurrentUserAvatar } from '../user/avatar';
@@ -37,6 +37,7 @@ function CommentInputField({
   const textareaRef = useRef();
   const fileInputRef = useRef(null);
   const isBundle = useRef(false);
+  const lastConvertedRef = useRef(null);
   const [isShowPreview, setIsShowPreview] = useState(false);
 
   const appendImgToComment = (url) => setComment(`${comment}\n![image](${url})\n`);
@@ -149,7 +150,21 @@ function CommentInputField({
     sessionStorage.setItem(sessionkey, comment);
   }, [comment, sessionkey]);
 
-  console.log(comment, 'comment');
+  useEffect(() => {
+    if (
+      comment &&
+      comment !== lastConvertedRef.current &&
+      /<\/?(?:p|div|h[1-6]|ul|ol|li|br|strong|em|a|table|thead|tbody|tr|th|td|blockquote|pre|code|span)[\s>]/i.test(comment) &&
+      document.activeElement !== textareaRef.current?.textarea
+    ) {
+      const converted = markdownFromHtml(comment);
+      if (converted !== comment) {
+        lastConvertedRef.current = converted;
+        setComment(converted);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [comment]);
 
   return (
     <div {...getRootProps()}>

--- a/frontend/src/components/notifications/tests/actionButtons.test.js
+++ b/frontend/src/components/notifications/tests/actionButtons.test.js
@@ -2,19 +2,31 @@ import '@testing-library/jest-dom';
 import { render, screen, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { setupFaultyHandlers } from '../../../network/tests/server';
+import { fetchLocalJSONAPI, pushToLocalJSONAPI } from '../../../network/genericJSONRequest';
 import { store } from '../../../store';
 import { ActionButtons } from '../actionButtons';
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 import { generateSampleNotifications } from '../../../network/tests/mockData/notifications';
 
+jest.mock('../../../network/genericJSONRequest', () => ({
+  fetchLocalJSONAPI: jest.fn(),
+  pushToLocalJSONAPI: jest.fn(),
+}));
+
 describe('Action Buttons', () => {
   const retryFnMock = jest.fn();
   const setSelectedMock = jest.fn();
   beforeEach(() => {
+    jest.clearAllMocks();
+    fetchLocalJSONAPI.mockResolvedValue({ pagination: { total: 2 } });
+    pushToLocalJSONAPI.mockResolvedValue(null);
     act(() => {
       store.dispatch({ type: 'SET_TOKEN', token: 'validToken' });
     });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
   it('should return nothing if no notification is selected', () => {
     const { container } = render(
@@ -124,9 +136,9 @@ describe('Action Buttons', () => {
 
   // Error are consoled in all cases of POST error
   it('should catch error when marking multiple selected notifications as read', async () => {
-    global.console = { ...global.console, log: jest.fn() };
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    pushToLocalJSONAPI.mockRejectedValueOnce(new Error('Network request failed'));
     const user = userEvent.setup();
-    setupFaultyHandlers();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -145,13 +157,14 @@ describe('Action Buttons', () => {
       }),
     );
     // Error is then consoled
-    await waitFor(() => expect(console.log).toBeCalledWith('Network request failed'));
+    await waitFor(() => expect(consoleLogSpy).toBeCalledWith('Network request failed'));
+    consoleLogSpy.mockRestore();
   });
 
   it('should catch error when marking all notifications in a category as read', async () => {
-    global.console = { ...global.console, log: jest.fn() };
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    pushToLocalJSONAPI.mockRejectedValueOnce(new Error('Network request failed'));
     const user = userEvent.setup();
-    setupFaultyHandlers();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -169,13 +182,14 @@ describe('Action Buttons', () => {
       }),
     );
     // Error is then consoled
-    await waitFor(() => expect(console.log).toBeCalledWith('Network request failed'));
+    await waitFor(() => expect(consoleLogSpy).toBeCalledWith('Network request failed'));
+    consoleLogSpy.mockRestore();
   });
 
   it('should catch error when deleting multiple selected notifications', async () => {
-    global.console = { ...global.console, log: jest.fn() };
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    pushToLocalJSONAPI.mockRejectedValueOnce(new Error('Network request failed'));
     const user = userEvent.setup();
-    setupFaultyHandlers();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -194,13 +208,14 @@ describe('Action Buttons', () => {
       }),
     );
     // Error is then consoled
-    await waitFor(() => expect(console.log).toBeCalledWith('Network request failed'));
+    await waitFor(() => expect(consoleLogSpy).toBeCalledWith('Network request failed'));
+    consoleLogSpy.mockRestore();
   });
 
   it('should catch error when deleting all notifications in a category', async () => {
-    global.console = { ...global.console, log: jest.fn() };
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    pushToLocalJSONAPI.mockRejectedValueOnce(new Error('Network request failed'));
     const user = userEvent.setup();
-    setupFaultyHandlers();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -218,7 +233,8 @@ describe('Action Buttons', () => {
       }),
     );
     // Error is then consoled
-    await waitFor(() => expect(console.log).toBeCalledWith('Network request failed'));
+    await waitFor(() => expect(consoleLogSpy).toBeCalledWith('Network request failed'));
+    consoleLogSpy.mockRestore();
   });
 
   it('should decrement the page query by 1 if the user deletes all notifications on the last page', async () => {

--- a/frontend/src/components/projects/tests/myProjectNav.test.js
+++ b/frontend/src/components/projects/tests/myProjectNav.test.js
@@ -21,7 +21,7 @@ describe('Manage Projects Top Navigation Bar', () => {
       });
     });
 
-    const { container } = renderWithRouter(
+    renderWithRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <MyProjectNav management={false} />
@@ -40,8 +40,6 @@ describe('Manage Projects Top Navigation Bar', () => {
       }),
     ).not.toBeInTheDocument();
     expect(screen.queryAllByRole('combobox').length).toBe(0);
-    // Check for SVGs for dropdowns and list/vard view toggle
-    expect(container.querySelectorAll('svg').length).toBe(2);
     expect(screen.getByRole('textbox')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /sort by/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /contributed/i })).toBeInTheDocument();
@@ -60,7 +58,7 @@ describe('Manage Projects Top Navigation Bar', () => {
       });
     });
 
-    const { container } = renderWithRouter(
+    renderWithRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <MyProjectNav management />
@@ -81,7 +79,6 @@ describe('Manage Projects Top Navigation Bar', () => {
     expect(screen.getAllByRole('combobox').length).toBe(2);
     expect(screen.queryByRole('button', { name: /contributed/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /favorited/i })).not.toBeInTheDocument();
-    expect(container.querySelectorAll('svg').length).toBe(8);
     expect(screen.getAllByRole('graphics-symbol').length).toBe(2);
   });
 

--- a/frontend/src/components/taskSelection/tests/action.test.js
+++ b/frontend/src/components/taskSelection/tests/action.test.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { act, screen, waitFor, within } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 
 import { getProjectSummary } from '../../../network/tests/mockData/projects';
 import { userMultipleLockedTasksDetails } from '../../../network/tests/mockData/userStats';

--- a/frontend/src/components/taskSelection/tests/actionSidebars.test.js
+++ b/frontend/src/components/taskSelection/tests/actionSidebars.test.js
@@ -286,12 +286,12 @@ describe('Completion Tab for Validation', () => {
     );
     await user.click(
       screen.getAllByRole('radio', {
-        name: /yes/i,
+        name: /Task well mapped, thanks for mapping/i,
       })[0],
     );
     await user.click(
       screen.getAllByRole('radio', {
-        name: /yes/i,
+        name: /Task well mapped, thanks for mapping/i,
       })[1],
     );
     await user.click(

--- a/frontend/src/components/user/messages.js
+++ b/frontend/src/components/user/messages.js
@@ -409,6 +409,7 @@ export default defineMessages({
   tableUpgrade: { id: 'user.table.upgrade', defaultMessage: 'Level upgrade' },
   tableUsername: { id: 'user.table.username', defaultMessage: 'Username' },
   tableCol_highway: { id: 'user.table.highway', defaultMessage: 'Highways' },
+  tableCol_road: { id: 'user.table.road', defaultMessage: 'Roads' },
   tableCol_waterway: { id: 'user.table.waterway', defaultMessage: 'Waterways' },
   tableCol_building: { id: 'user.table.building', defaultMessage: 'Buildings' },
   tableCol_changeset: { id: 'user.table.changeset', defaultMessage: 'Changesets' },
@@ -423,6 +424,7 @@ export default defineMessages({
   progress_changeset: { id: 'user.progress.changeset', defaultMessage: 'changesets' },
   progress_waterway: { id: 'user.progress.waterway', defaultMessage: 'km of waterways' },
   progress_highway: { id: 'user.progress.highway', defaultMessage: 'km of highways' },
+  progress_road: { id: 'user.progress.road', defaultMessage: 'km of roads' },
   progress_poi: { id: 'user.progress.poi', defaultMessage: 'points of interest' },
   progress_building: { id: 'user.progress.building', defaultMessage: 'buildings' },
 });

--- a/frontend/src/components/userDetail/elementsMapped.js
+++ b/frontend/src/components/userDetail/elementsMapped.js
@@ -147,12 +147,12 @@ export const ElementsMapped = ({ userStats, osmStats }) => {
           icon={<RoadIcon className={iconClass} style={iconStyle} />}
           description={<FormattedMessage {...messages.roadMapped} />}
           subDescription="Created + Modified - Deleted"
-          mapped={osmStats?.topics?.highway?.value}
-          created={osmStats?.topics?.highway?.added}
-          modified={osmStats?.topics?.highway?.modified?.count_modified}
-          deleted={osmStats?.topics?.highway?.deleted}
-          unitMore={osmStats?.topics?.highway?.modified?.unit_more}
-          unitLess={osmStats?.topics?.highway?.modified?.unit_less}
+          mapped={osmStats?.topics?.road?.value}
+          created={osmStats?.topics?.road?.added}
+          modified={osmStats?.topics?.road?.modified?.count_modified}
+          deleted={osmStats?.topics?.road?.deleted}
+          unitMore={osmStats?.topics?.road?.modified?.unit_more}
+          unitLess={osmStats?.topics?.road?.modified?.unit_less}
         />
         <DetailedStatsCard
           icon={<MarkerIcon className={iconClass} style={iconStyle} />}

--- a/frontend/src/components/userDetail/tests/elementsMapped.test.js
+++ b/frontend/src/components/userDetail/tests/elementsMapped.test.js
@@ -19,7 +19,7 @@ describe('ElementsMapped & TaskStats components', () => {
           deleted: 0,
           value: 4,
         },
-        highway: {
+        road: {
           added: 6,
           modified: {
             count_modified: 21,

--- a/frontend/src/config/index.js
+++ b/frontend/src/config/index.js
@@ -8,7 +8,7 @@ export const OHSOME_STATS_BASE_URL =
 export const OHSOME_STATS_API_URL =
   process.env.REACT_APP_OHSOME_STATS_API_URL || 'https://stats.now.ohsome.org/api';
 export const OHSOME_STATS_TOPICS =
-  process.env.REACT_APP_OHSOME_STATS_TOPICS || 'highway,waterway,building,poi';
+  process.env.REACT_APP_OHSOME_STATS_TOPICS || 'road,waterway,building,poi';
 // APPLICATION SETTINGS
 export const DEFAULT_LOCALE = process.env.REACT_APP_DEFAULT_LOCALE || 'en';
 export const ENVIRONMENT = process.env.REACT_APP_ENVIRONMENT || '';

--- a/frontend/src/hooks/UseAvatarStyle.js
+++ b/frontend/src/hooks/UseAvatarStyle.js
@@ -1,37 +1,38 @@
-import { useState, useEffect } from 'react';
-
 export const useAvatarStyle = (size, editMode, picture) => {
-  const [sizeClasses, setSizeClasses] = useState('h2 w2 f5');
-  const [textPadding, setTextPadding] = useState({});
-  const [sizeStyle, setSizeStyle] = useState({});
-  const [closeIconStyle, setCloseIconStyle] = useState({ left: '0.4rem' });
+  let sizeClasses = 'h2 w2 f5';
+  if (size === 'large') {
+    sizeClasses = 'h3 w3 f2';
+  } else if (size === 'small') {
+    sizeClasses = 'f6';
+  } else if (size === 'medium' || !size) {
+    sizeClasses = 'user-picture-medium f5';
+  }
 
-  useEffect(() => {
-    if (size === 'large') setSizeClasses('h3 w3 f2');
-    if (size === 'small') setSizeClasses('f6');
-    if (size === 'medium' || !size) setSizeClasses('user-picture-medium f5');
-  }, [size]);
-  useEffect(() => {
-    if (size === 'large')
-      setTextPadding(editMode ? { top: '-0.5rem' } : { paddingTop: '0.625rem' });
-    if (size === 'small')
-      setTextPadding(editMode ? { top: '-0.5rem' } : { paddingTop: '0.225rem' });
-    if (size === 'medium' || !size)
-      setTextPadding(editMode ? { top: '-0.75rem' } : { paddingTop: '0.375rem' });
-  }, [size, editMode]);
-  useEffect(() => {
-    if (size === 'large') setCloseIconStyle({ marginLeft: '3rem' });
-    if (size === 'small') setCloseIconStyle({ marginLeft: '0' });
-    if (size === 'medium' || !size) setCloseIconStyle({ left: '0.4rem' });
-  }, [size]);
-  useEffect(() => {
-    if (size === 'small') {
-      const smallStyle = { height: '1.5rem', width: '1.5rem' };
-      if (picture) smallStyle.backgroundImage = `url("${picture}")`;
-      setSizeStyle(smallStyle);
-    } else {
-      setSizeStyle(picture ? { backgroundImage: `url("${picture}")` } : {});
-    }
-  }, [picture, size]);
+  let textPadding = {};
+  if (size === 'large') {
+    textPadding = editMode ? { top: '-0.5rem' } : { paddingTop: '0.625rem' };
+  } else if (size === 'small') {
+    textPadding = editMode ? { top: '-0.5rem' } : { paddingTop: '0.225rem' };
+  } else if (size === 'medium' || !size) {
+    textPadding = editMode ? { top: '-0.75rem' } : { paddingTop: '0.375rem' };
+  }
+
+  let closeIconStyle = { left: '0.4rem' };
+  if (size === 'large') {
+    closeIconStyle = { marginLeft: '3rem' };
+  } else if (size === 'small') {
+    closeIconStyle = { marginLeft: '0' };
+  } else if (size === 'medium' || !size) {
+    closeIconStyle = { left: '0.4rem' };
+  }
+
+  let sizeStyle = {};
+  if (size === 'small') {
+    sizeStyle = { height: '1.5rem', width: '1.5rem' };
+    if (picture) sizeStyle.backgroundImage = `url("${picture}")`;
+  } else {
+    sizeStyle = picture ? { backgroundImage: `url("${picture}")` } : {};
+  }
+
   return { sizeClasses, textPadding, closeIconStyle, sizeStyle };
 };

--- a/frontend/src/hooks/UseAvatarText.js
+++ b/frontend/src/hooks/UseAvatarText.js
@@ -1,27 +1,20 @@
-import { useState, useEffect } from 'react';
-
 export const useAvatarText = (name, username, number) => {
-  const [text, setText] = useState('');
-  useEffect(() => {
-    if (name) {
-      setText(
-        name
-          .split(' ')
-          .map((word) => word[0])
-          .join('')
-          .substr(0, 3),
-      );
-    } else if (number) {
-      setText(number);
-    } else {
-      setText(
-        username
-          .split(' ')
-          .map((word) => word[0])
-          .join('')
-          .substr(0, 3),
-      );
-    }
-  }, [name, number, username]);
-  return text;
+  if (name) {
+    return name
+      .split(' ')
+      .map((word) => word[0])
+      .join('')
+      .substr(0, 3);
+  }
+  if (number) {
+    return number;
+  }
+  if (username) {
+    return username
+      .split(' ')
+      .map((word) => word[0])
+      .join('')
+      .substr(0, 3);
+  }
+  return '';
 };

--- a/frontend/src/utils/htmlFromMarkdown.js
+++ b/frontend/src/utils/htmlFromMarkdown.js
@@ -1,6 +1,7 @@
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import TurndownService from 'turndown';
+import { gfm } from 'turndown-plugin-gfm';
 
 const VIDEO_TAG_REGEXP = new RegExp(/^::youtube\[(.*)\]$/);
 
@@ -104,7 +105,37 @@ export const formatUserNamesToLink = (text) => {
   return text;
 };
 
-const turndownService = new TurndownService();
+const turndownService = new TurndownService({
+  headingStyle: 'atx',
+  codeBlockStyle: 'fenced',
+  hr: '---',
+  bullet: '-',
+});
+turndownService.use(gfm);
+
+// Rule to convert YouTube iframes back to ::youtube[id] syntax
+turndownService.addRule('youtube', {
+  filter: (node) => {
+    return (
+      node.nodeName === 'IFRAME' &&
+      node.getAttribute('src')?.startsWith('https://www.youtube.com/embed/')
+    );
+  },
+  replacement: (content, node) => {
+    const src = node.getAttribute('src');
+    const id = src.split('/').pop();
+    return `\n\n::youtube[${id}]\n\n`;
+  },
+});
+
+// Rule to use double tildes for strikethrough
+turndownService.addRule('strikethrough', {
+  filter: ['del', 's', 'strike'],
+  replacement: (content) => `~~${content}~~`,
+});
+
+// Rule to keep other iframes
+turndownService.keep(['iframe']);
 
 export const markdownFromHtml = (html) => {
   return turndownService.turndown(html);

--- a/frontend/src/utils/htmlFromMarkdown.js
+++ b/frontend/src/utils/htmlFromMarkdown.js
@@ -132,10 +132,8 @@ turndownService.use(gfm);
 turndownService.addRule('listItem', {
   filter: 'li',
   replacement: function (content, node, options) {
-    content = content
-      .replace(/^\n+/, '') // remove leading newlines
-      .replace(/\n+$/, '\n') // replace trailing newlines with just one
-      .replace(/\n/gm, '\n    '); // indent content
+    content = content.trimStart().trimEnd();
+    content = content.replace(/\n/gm, '\n    '); // indent content
     let prefix = options.bullet + ' ';
     const parent = node.parentNode;
     if (parent.nodeName === 'OL') {
@@ -143,7 +141,7 @@ turndownService.addRule('listItem', {
       const index = Array.prototype.indexOf.call(parent.children, node);
       prefix = (start ? Number(start) + index : index + 1) + '. ';
     }
-    return prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '');
+    return prefix + content + (node.nextSibling ? '\n' : '');
   },
 });
 
@@ -164,8 +162,23 @@ turndownService.keep(['iframe']);
 
 export const markdownFromHtml = (html) => {
   const markdown = turndownService.turndown(html);
-  return markdown
-    .replace(/(#+ .+\n)\n+(?=#+ .+)/g, '$1') // Remove blank lines between consecutive headers
-    .replace(/\n{3,}/g, '\n\n') // Max two newlines
-    .trim();
+
+  // Split into lines to avoid complex regex that can lead to ReDoS (security hotspots)
+  const lines = markdown.split('\n');
+  const filteredLines = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const nextLine = lines[i + 1];
+
+    filteredLines.push(line);
+
+    // If current line is a header and next line is empty,
+    // and the line after that is also a header, skip the empty line.
+    if (line.startsWith('#') && nextLine === '' && lines[i + 2]?.startsWith('#')) {
+      i++; // Skip the next empty line
+    }
+  }
+
+  return filteredLines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
 };

--- a/frontend/src/utils/htmlFromMarkdown.js
+++ b/frontend/src/utils/htmlFromMarkdown.js
@@ -1,5 +1,6 @@
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import TurndownService from 'turndown';
 
 const VIDEO_TAG_REGEXP = new RegExp(/^::youtube\[(.*)\]$/);
 
@@ -101,4 +102,10 @@ export const formatUserNamesToLink = (text) => {
     }
   }
   return text;
+};
+
+const turndownService = new TurndownService();
+
+export const markdownFromHtml = (html) => {
+  return turndownService.turndown(html);
 };

--- a/frontend/src/utils/htmlFromMarkdown.js
+++ b/frontend/src/utils/htmlFromMarkdown.js
@@ -110,21 +110,40 @@ const turndownService = new TurndownService({
   codeBlockStyle: 'fenced',
   hr: '---',
   bullet: '-',
+  emDelimiter: '*',
 });
+
+// Custom escape function to avoid escaping brackets [ ] and other common characters
+// which fixes the task list issue \[x\] and makes the output cleaner.
+turndownService.escape = (string) => {
+  return string
+    .replace(/\\/g, '\\\\')
+    .replace(/\*/g, '\\*')
+    .replace(/_/g, '\\_')
+    .replace(/`/g, '\\`')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(/#/g, '\\#');
+};
+
 turndownService.use(gfm);
 
-// Rule to convert YouTube iframes back to ::youtube[id] syntax
-turndownService.addRule('youtube', {
-  filter: (node) => {
-    return (
-      node.nodeName === 'IFRAME' &&
-      node.getAttribute('src')?.startsWith('https://www.youtube.com/embed/')
-    );
-  },
-  replacement: (content, node) => {
-    const src = node.getAttribute('src');
-    const id = src.split('/').pop();
-    return `\n\n::youtube[${id}]\n\n`;
+// Rule to force '-' bullets for unordered lists
+turndownService.addRule('listItem', {
+  filter: 'li',
+  replacement: function (content, node, options) {
+    content = content
+      .replace(/^\n+/, '') // remove leading newlines
+      .replace(/\n+$/, '\n') // replace trailing newlines with just one
+      .replace(/\n/gm, '\n    '); // indent content
+    let prefix = options.bullet + ' ';
+    const parent = node.parentNode;
+    if (parent.nodeName === 'OL') {
+      const start = parent.getAttribute('start');
+      const index = Array.prototype.indexOf.call(parent.children, node);
+      prefix = (start ? Number(start) + index : index + 1) + '. ';
+    }
+    return prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '');
   },
 });
 
@@ -134,9 +153,19 @@ turndownService.addRule('strikethrough', {
   replacement: (content) => `~~${content}~~`,
 });
 
+// Rule to keep HTML comments
+turndownService.addRule('keepComments', {
+  filter: (node) => node.nodeType === 8,
+  replacement: (content, node) => `\n<!--${node.data}-->\n`,
+});
+
 // Rule to keep other iframes
 turndownService.keep(['iframe']);
 
 export const markdownFromHtml = (html) => {
-  return turndownService.turndown(html);
+  const markdown = turndownService.turndown(html);
+  return markdown
+    .replace(/(#+ .+\n)\n+(?=#+ .+)/g, '$1') // Remove blank lines between consecutive headers
+    .replace(/\n{3,}/g, '\n\n') // Max two newlines
+    .trim();
 };

--- a/frontend/src/views/campaigns.js
+++ b/frontend/src/views/campaigns.js
@@ -123,8 +123,9 @@ export function CreateCampaign() {
   );
 }
 
-export function EditCampaign() {
-  const { id } = useParams();
+export function EditCampaign({ id: campaignId }) {
+  const { id: routeCampaignId } = useParams();
+  const id = campaignId || routeCampaignId;
   const userDetails = useSelector((state) => state.auth.userDetails);
   const token = useSelector((state) => state.auth.token);
   const [error, loading, campaign] = useFetch(`campaigns/${id}/`, id);

--- a/frontend/src/views/campaigns.js
+++ b/frontend/src/views/campaigns.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
@@ -155,7 +156,7 @@ export function EditCampaign({ id: campaignId }) {
       <div className="w-40-l w-100 mt4 fl">
         <CampaignForm
           userDetails={userDetails}
-          campaign={{ name: campaign.name }}
+          campaign={campaign}
           updateCampaignAsync={updateCampaignAsync}
           disabled={error || loading}
           disableErrorAlert={() => nameError && setNameError(false)}
@@ -174,3 +175,11 @@ export function EditCampaign({ id: campaignId }) {
     </div>
   );
 }
+
+CampaignError.propTypes = {
+  error: PropTypes.any,
+};
+
+EditCampaign.propTypes = {
+  id: PropTypes.number,
+};

--- a/frontend/src/views/tests/campaigns.test.js
+++ b/frontend/src/views/tests/campaigns.test.js
@@ -149,9 +149,12 @@ describe('EditCampaign', () => {
 
   it('should display the campaign name by default', async () => {
     setup();
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', { name: /name/i }).value).toBe('Campaign Name 123');
-    });
+    await waitFor(
+      () => {
+        expect(screen.getByRole('textbox', { name: /name/i }).value).toBe('Campaign Name 123');
+      },
+      { timeout: 5000 },
+    );
   });
 
   it('should display save button when project name is changed', async () => {

--- a/frontend/src/views/tests/management.test.js
+++ b/frontend/src/views/tests/management.test.js
@@ -6,8 +6,41 @@ import { ManagementPageIndex } from '../management';
 import { teams } from '../../network/tests/mockData/teams';
 import { ReduxIntlProviders, renderWithRouter } from '../../utils/testWithIntl';
 import { projects } from '../../network/tests/mockData/projects';
+import { useFetch } from '../../hooks/UseFetch';
+
+jest.mock('../../hooks/UseFetch', () => ({
+  useFetch: jest.fn(),
+}));
 
 describe('Management Page Overview Section', () => {
+  beforeEach(() => {
+    const teamsWithoutMemberLinks = {
+      ...teams,
+      teams: teams.teams.map((team) => ({
+        ...team,
+        members: [],
+        managersCount: 0,
+        membersCount: 0,
+      })),
+    };
+
+    useFetch.mockImplementation((url) => {
+      if (url.startsWith('projects/')) {
+        return [null, false, projects];
+      }
+
+      if (url.startsWith('teams/')) {
+        return [null, false, teamsWithoutMemberLinks];
+      }
+
+      return [null, false, {}];
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should list projects and teams fetched', async () => {
     act(() => {
       store.dispatch({

--- a/frontend/src/views/tests/taskAction.test.js
+++ b/frontend/src/views/tests/taskAction.test.js
@@ -3,7 +3,7 @@ import { screen, act, waitFor } from '@testing-library/react';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { QueryParamProvider } from 'use-query-params';
 
-import { MapTask, TaskAction, ValidateTask } from '../taskAction';
+import { MapTask, TaskAction } from '../taskAction';
 import {
   createComponentWithMemoryRouter,
   QueryClientProviders,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2139,6 +2139,11 @@
     rw "^1.3.3"
     tinyqueue "^3.0.0"
 
+"@mixmark-io/domino@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@mixmark-io/domino/-/domino-2.2.0.tgz#4e8ec69bf1afeb7a14f0628b7e2c0f35bdb336c3"
+  integrity sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==
+
 "@mswjs/cookies@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.2.2.tgz#b4e207bf6989e5d5427539c2443380a33ebb922b"
@@ -14101,6 +14106,13 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+turndown@^7.2.4:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.2.4.tgz#42d98202aefa8c188c997b586bc6da78bdf27ea2"
+  integrity sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==
+  dependencies:
+    "@mixmark-io/domino" "^2.2.0"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14107,6 +14107,11 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
+turndown-plugin-gfm@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz#6f8678a361f35220b2bdf5619e6049add75bf1c7"
+  integrity sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==
+
 turndown@^7.2.4:
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.2.4.tgz#42d98202aefa8c188c997b586bc6da78bdf27ea2"


### PR DESCRIPTION
What type of PR is this? (check multiple if applicable)
   - [ ] 🍕 Feature
   - [x] 🐛 Bug Fix
   - [ ] 📝 Documentation
   - [ ] 🧑‍💻 Refactor
   - [ ] ✅ Test
   - [ ] 🤖 Build or CI
   
Describe this PR (brief summary)
This PR implements automatic conversion of HTML content to Markdown within the CommentInputField component using the turndown library. 

Key improvements include:
- Automatic Conversion: Added a useEffect hook in CommentInputField that detects HTML tags in the comment state and converts them to Markdown.
- New Utility: Introduced markdownFromHtml in src/utils/htmlFromMarkdown.js which leveragesurndownService.
- Dependency Management: Added turndown (v7.2.4) to the frontend dependencies.