### PR TITLE
fix: fetch sandbox editor map data in z18 tiles to avoid OSM API node…

### DIFF
--- a/frontend/src/components/sandboxEditor.js
+++ b/frontend/src/components/sandboxEditor.js
@@ -161,6 +161,12 @@ export default function SandboxEditor({
           access_token: tokenData.access_token,
         });
 
+        // Fetch map data in z18 tiles (1/16th the area of iD's default z16) so each
+        // /api/0.6/map.json request stays under the OSM API's 50k-node limit in
+        // densely mapped sandbox areas, where a single z16 tile would otherwise
+        // return a 400 "You requested too many nodes".
+        iDContext.connection().tileZoom(18);
+
         const thereAreChanges = (changes) =>
           changes.modified.length || changes.created.length || changes.deleted.length;
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)


## Describe this PR

The @osm-sandbox/sandbox-id editor hardcodes its data-fetch tile size to zoom 16 (_tileZoom = 16), so every /api/0.6/map.json request covers a single ~605m-wide z16 tile. In densely mapped sandbox areas (e.g. the seagrass project), one z16 tile exceeds the OSM API's 50,000-node limit and requests fail with 400 "You requested too many nodes" and features never load in the editor.

This PR calls the editor's public runtime setter connection().tileZoom(18) immediately after connection().switch(...) in sandboxEditor.js. Data is then fetched in z18 tiles (1/16th the area of the default z16), keeping per-request node counts under the 50k limit.

No viewport/extent changes and no changes to the regular (non-sandbox) OSM editor.

**Result:**  When opening a sandbox task, /api/0.6/map.json requests now use bbox widths of ~0.00137° (360/2¹⁸) instead of ~0.00549° (360/2¹⁶) and return 200.
